### PR TITLE
1A-2: useVehicleLookup function + tests

### DIFF
--- a/assets/js/hooks/useVehicleLookup.js
+++ b/assets/js/hooks/useVehicleLookup.js
@@ -1,0 +1,46 @@
+const models = require('../data/vehicle-models.json');
+
+// Build a simple index at module load
+const INDEX = models.map((entry) => {
+  const make = entry.make.toLowerCase();
+  const model = entry.model.toLowerCase();
+  return {
+    make,
+    model,
+    combined: `${make} ${model}`,
+    size: entry.size,
+  };
+});
+
+const DEFAULT_SIZE = 'sedan';
+
+module.exports = function useVehicleLookup(searchTerm) {
+  if (typeof searchTerm !== 'string') return null;
+  const term = searchTerm.trim().toLowerCase();
+  if (!term) return null;
+
+  const counts = {};
+  for (const item of INDEX) {
+    if (
+      item.make.includes(term) ||
+      item.model.includes(term) ||
+      item.combined.includes(term)
+    ) {
+      counts[item.size] = (counts[item.size] || 0) + 1;
+    }
+  }
+
+  const entries = Object.entries(counts);
+  if (entries.length === 0) return null;
+
+  let max = 0;
+  for (const [, count] of entries) {
+    if (count > max) max = count;
+  }
+
+  const topSizes = entries
+    .filter(([, count]) => count === max)
+    .map(([size]) => size);
+
+  return topSizes.length === 1 ? topSizes[0] : DEFAULT_SIZE;
+};

--- a/test/useVehicleLookup.test.js
+++ b/test/useVehicleLookup.test.js
@@ -1,0 +1,24 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const useVehicleLookup = require('../assets/js/hooks/useVehicleLookup');
+
+test('exact make and model match returns sedan', () => {
+  assert.equal(useVehicleLookup('Toyota Camry'), 'sedan');
+});
+
+test('partial match returns sedan', () => {
+  assert.equal(useVehicleLookup('camr'), 'sedan');
+});
+
+test('tie breaker returns sedan', () => {
+  assert.equal(useVehicleLookup('Ford'), 'sedan');
+});
+
+test('not found or empty input returns null', () => {
+  assert.equal(useVehicleLookup('unknown'), null);
+  assert.equal(useVehicleLookup(''), null);
+  assert.equal(useVehicleLookup('   '), null);
+  assert.equal(useVehicleLookup(null), null);
+  assert.equal(useVehicleLookup(undefined), null);
+});


### PR DESCRIPTION
## Summary
- add vehicle lookup function using in-memory index
- cover vehicle lookup scenarios with node:test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfd47fc7483238ebe3ef923f30b3a