### PR TITLE
Fix ci to allow npm i without lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,45 @@
-steps:
-  - uses: actions/checkout@v4
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'codex/**'
 
-  # Only set up Node if there's a package.json
-  - uses: actions/setup-node@v4
-    if: ${{ hashFiles('package.json') != '' }}
-    with:
-      node-version: '20'
-      cache: 'npm'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-  # If we have a lockfile, use ci; otherwise install
-  - name: Install deps
-    if: ${{ hashFiles('package.json') != '' }}
-    run: |
-      if [ -f package-lock.json ]; then
-        npm ci
-      else
-        npm i
-      fi
+      - uses: actions/setup-node@v4
+        if: ${{ hashFiles('package.json') != '' }}
+        with:
+          node-version: '20'
+          cache: npm
 
-  - run: npm run lint --if-present
-    if: ${{ hashFiles('package.json') != '' }}
+      - name: Install deps
+        if: ${{ hashFiles('package.json') != '' }}
+        shell: bash
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm i
+          fi
 
-  - run: npm run typecheck --if-present
-    if: ${{ hashFiles('package.json') != '' }}
+      - name: Lint
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run lint --if-present
 
-  - run: npm test --if-present
-    if: ${{ hashFiles('package.json') != '' }}
+      - name: Typecheck
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run typecheck --if-present
 
-  - run: npm run build --if-present
-    if: ${{ hashFiles('package.json') != '' }}
+      - name: Test
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm test --if-present
+
+      - name: Build
+        if: ${{ hashFiles('package.json') != '' }}
+        run: npm run build --if-present
 


### PR DESCRIPTION
Update CI workflow to fall back to `npm i` when `package-lock.json` is missing and gate Node steps on `package.json` presence.

---
<a href="https://cursor.com/background-agent?bcId=bc-03382aab-8620-4838-b207-48d84ac3d1c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03382aab-8620-4838-b207-48d84ac3d1c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

