### PR TITLE
1A-3: VehicleSizeTiles (vanilla stub) + polish

### DIFF
--- a/wp-content/plugins/cleverlux-quote/assets/css/admin.css
+++ b/wp-content/plugins/cleverlux-quote/assets/css/admin.css
@@ -1,0 +1,237 @@
+/* CleverLux Admin Styles */
+.cleverlux-admin-page {
+	max-width: 800px;
+	margin: 2rem auto;
+}
+
+.cleverlux-admin-page .wp-heading-inline {
+	margin-bottom: 1.5rem;
+	padding-bottom: 0.75rem;
+	border-bottom: 2px solid #e1e5e9;
+	color: #0A1A2F;
+}
+
+.admin-content {
+	background: #ffffff;
+	padding: 2rem;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.cleverlux-settings-form {
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+}
+
+.settings-section {
+	margin-bottom: 1.5rem;
+}
+
+.settings-section h2 {
+	font-size: 1.5rem;
+	font-weight: 600;
+	color: #333;
+	margin-bottom: 0.75rem;
+	padding-bottom: 0.5rem;
+	border-bottom: 1px solid #e1e5e9;
+}
+
+.settings-section .description {
+	font-size: 0.95rem;
+	color: #666;
+	line-height: 1.5;
+	margin-bottom: 1rem;
+}
+
+.submit-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding-top: 1.5rem;
+	border-top: 2px solid #e1e5e9;
+}
+
+/* WordPress Button Enhancements */
+.wp-core-ui .button-primary {
+	background: #0A1A2F;
+	border-color: #0A1A2F;
+	color: #ffffff;
+	padding: 0.75rem 1.5rem;
+	font-size: 1rem;
+	font-weight: 600;
+	border-radius: 6px;
+	transition: all 0.2s ease;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.wp-core-ui .button-primary:hover {
+	background: #1a2a3f;
+	border-color: #1a2a3f;
+	transform: translateY(-1px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.wp-core-ui .button-primary:focus {
+	outline: none;
+	background: #1a2a3f;
+	border-color: #1a2a3f;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.3);
+}
+
+.wp-core-ui .button-primary:active {
+	transform: translateY(0);
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Form Field Enhancements */
+.cleverlux-settings-form input[type="text"],
+.cleverlux-settings-form input[type="number"],
+.cleverlux-settings-form select,
+.cleverlux-settings-form textarea {
+	padding: 0.75rem;
+	border: 2px solid #e1e5e9;
+	border-radius: 6px;
+	font-size: 1rem;
+	background: #ffffff;
+	transition: border-color 0.2s ease, box-shadow 0.2s ease;
+	width: 100%;
+	max-width: 400px;
+}
+
+.cleverlux-settings-form input[type="text"]:focus,
+.cleverlux-settings-form input[type="number"]:focus,
+.cleverlux-settings-form select:focus,
+.cleverlux-settings-form textarea:focus {
+	outline: none;
+	border-color: #0A1A2F;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.1);
+}
+
+.cleverlux-settings-form input[type="text"]:hover,
+.cleverlux-settings-form input[type="number"]:hover,
+.cleverlux-settings-form select:hover,
+.cleverlux-settings-form textarea:hover {
+	border-color: #4a5568;
+}
+
+/* Checkbox and Radio Enhancements */
+.cleverlux-settings-form input[type="checkbox"],
+.cleverlux-settings-form input[type="radio"] {
+	width: 1.25rem;
+	height: 1.25rem;
+	accent-color: #0A1A2F;
+	margin-right: 0.5rem;
+}
+
+.cleverlux-settings-form input[type="checkbox"]:focus,
+.cleverlux-settings-form input[type="radio"]:focus {
+	outline: 2px solid #0A1A2F;
+	outline-offset: 2px;
+}
+
+/* Label Enhancements */
+.cleverlux-settings-form label {
+	font-weight: 600;
+	color: #333;
+	margin-bottom: 0.5rem;
+	display: block;
+}
+
+.cleverlux-settings-form .description {
+	font-size: 0.875rem;
+	color: #666;
+	margin-top: 0.25rem;
+	line-height: 1.4;
+}
+
+/* Table Enhancements */
+.cleverlux-settings-form table {
+	border-collapse: collapse;
+	width: 100%;
+	margin: 1rem 0;
+}
+
+.cleverlux-settings-form th,
+.cleverlux-settings-form td {
+	padding: 0.75rem;
+	border: 1px solid #e1e5e9;
+	text-align: left;
+}
+
+.cleverlux-settings-form th {
+	background: #f8f9fa;
+	font-weight: 600;
+	color: #333;
+}
+
+.cleverlux-settings-form tr:hover {
+	background: #f8f9fa;
+}
+
+/* Accessibility Improvements */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* Focus Visible for Keyboard Navigation */
+.cleverlux-settings-form *:focus-visible {
+	outline: 2px solid #0A1A2F;
+	outline-offset: 2px;
+}
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+	.admin-content {
+		border: 2px solid #000;
+	}
+	
+	.cleverlux-settings-form input[type="text"],
+	.cleverlux-settings-form input[type="number"],
+	.cleverlux-settings-form select,
+	.cleverlux-settings-form textarea {
+		border-width: 2px;
+	}
+	
+	.wp-core-ui .button-primary {
+		border: 2px solid #000;
+	}
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+	* {
+		transition: none !important;
+		animation: none !important;
+	}
+	
+	.wp-core-ui .button-primary:hover {
+		transform: none;
+	}
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+	.cleverlux-admin-page {
+		margin: 1rem;
+	}
+	
+	.admin-content {
+		padding: 1rem;
+	}
+	
+	.cleverlux-settings-form input[type="text"],
+	.cleverlux-settings-form input[type="number"],
+	.cleverlux-settings-form select,
+	.cleverlux-settings-form textarea {
+		max-width: 100%;
+	}
+}

--- a/wp-content/plugins/cleverlux-quote/assets/css/calculator.css
+++ b/wp-content/plugins/cleverlux-quote/assets/css/calculator.css
@@ -1,0 +1,277 @@
+/* CleverLux Quote Calculator Styles */
+.cleverlux-quote-calculator {
+	max-width: 600px;
+	margin: 2rem auto;
+	padding: 1.5rem;
+	background: #ffffff;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.quote-form {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.form-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.form-label {
+	font-weight: 600;
+	font-size: 1rem;
+	color: #333;
+	margin-bottom: 0.25rem;
+}
+
+.form-select {
+	padding: 0.75rem;
+	border: 2px solid #e1e5e9;
+	border-radius: 6px;
+	font-size: 1rem;
+	background: #ffffff;
+	transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-select:focus {
+	outline: none;
+	border-color: #0A1A2F;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.1);
+}
+
+.form-select:hover {
+	border-color: #4a5568;
+}
+
+/* Package Options */
+.package-options {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.package-option {
+	display: flex;
+	align-items: center;
+	padding: 1rem;
+	border: 2px solid #e1e5e9;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	position: relative;
+}
+
+.package-option:hover {
+	border-color: #4a5568;
+	background-color: #f8f9fa;
+}
+
+.package-option:focus-within {
+	border-color: #0A1A2F;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.1);
+}
+
+.package-radio {
+	margin-right: 0.75rem;
+	width: 1.25rem;
+	height: 1.25rem;
+	accent-color: #0A1A2F;
+}
+
+.package-radio:focus {
+	outline: 2px solid #0A1A2F;
+	outline-offset: 2px;
+}
+
+.package-name {
+	font-weight: 600;
+	font-size: 1.1rem;
+	color: #333;
+	flex: 1;
+}
+
+.package-price {
+	font-weight: 700;
+	font-size: 1.2rem;
+	color: #0A1A2F;
+}
+
+.package-desc {
+	font-size: 0.875rem;
+	color: #666;
+	margin-top: 0.25rem;
+	grid-column: 1 / -1;
+}
+
+/* Addon Options */
+.addon-options {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.addon-option {
+	display: flex;
+	align-items: center;
+	padding: 0.75rem;
+	border: 2px solid #e1e5e9;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.addon-option:hover {
+	border-color: #4a5568;
+	background-color: #f8f9fa;
+}
+
+.addon-option:focus-within {
+	border-color: #0A1A2F;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.1);
+}
+
+.addon-checkbox {
+	margin-right: 0.75rem;
+	width: 1.125rem;
+	height: 1.125rem;
+	accent-color: #0A1A2F;
+}
+
+.addon-checkbox:focus {
+	outline: 2px solid #0A1A2F;
+	outline-offset: 2px;
+}
+
+.addon-name {
+	font-size: 1rem;
+	color: #333;
+	flex: 1;
+}
+
+.addon-price {
+	font-weight: 600;
+	color: #0A1A2F;
+}
+
+/* Quote Summary */
+.quote-summary {
+	margin-top: 1rem;
+	padding: 1rem;
+	background: #f8f9fa;
+	border-radius: 6px;
+	border: 2px solid #e1e5e9;
+}
+
+.total-price {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 1.25rem;
+	font-weight: 700;
+}
+
+.total-label {
+	color: #333;
+}
+
+.total-amount {
+	color: #0A1A2F;
+	font-size: 1.5rem;
+}
+
+/* Submit Button */
+.submit-button {
+	padding: 1rem 2rem;
+	background: #0A1A2F;
+	color: #ffffff;
+	border: none;
+	border-radius: 6px;
+	font-size: 1.1rem;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	margin-top: 1rem;
+}
+
+.submit-button:hover {
+	background: #1a2a3f;
+	transform: translateY(-1px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.submit-button:focus {
+	outline: none;
+	background: #1a2a3f;
+	box-shadow: 0 0 0 3px rgba(10, 26, 47, 0.3);
+}
+
+.submit-button:active {
+	transform: translateY(0);
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.submit-button:disabled {
+	background: #ccc;
+	cursor: not-allowed;
+	transform: none;
+	box-shadow: none;
+}
+
+/* Help Text */
+.help-text {
+	font-size: 0.875rem;
+	color: #666;
+	margin-top: 0.25rem;
+}
+
+/* Screen Reader Only */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* Keyboard Navigation Improvements */
+.package-option:focus-visible,
+.addon-option:focus-visible {
+	outline: 2px solid #0A1A2F;
+	outline-offset: 2px;
+}
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+	.cleverlux-quote-calculator {
+		border: 2px solid #000;
+	}
+	
+	.form-select,
+	.package-option,
+	.addon-option {
+		border-width: 2px;
+	}
+	
+	.submit-button {
+		border: 2px solid #000;
+	}
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+	* {
+		transition: none !important;
+		animation: none !important;
+	}
+	
+	.submit-button:hover {
+		transform: none;
+	}
+}

--- a/wp-content/plugins/cleverlux-quote/assets/js/calculator.js
+++ b/wp-content/plugins/cleverlux-quote/assets/js/calculator.js
@@ -1,0 +1,266 @@
+/**
+ * CleverLux Quote Calculator JavaScript
+ * Handles form interactions, price calculations, and accessibility features
+ */
+
+(function() {
+	'use strict';
+
+	// Price matrix from PHP settings
+	const priceMatrix = {
+		sedan: { silver: 109, gold: 189, platinum: 299 },
+		sports: { silver: 129, gold: 219, platinum: 329 },
+		small_suv: { silver: 129, gold: 219, platinum: 329 },
+		large_suv: { silver: 149, gold: 249, platinum: 369 },
+		full_van: { silver: 169, gold: 279, platinum: 399 },
+		boat: { silver: 219, gold: 339, platinum: 499 }
+	};
+
+	// Addon prices from PHP settings
+	const addonPrices = [25, 35, 45, 35, 30];
+
+	let currentTotal = 0;
+
+	// Initialize calculator when DOM is ready
+	document.addEventListener('DOMContentLoaded', function() {
+		initializeCalculator();
+	});
+
+	function initializeCalculator() {
+		const form = document.getElementById('quote-form');
+		if (!form) return;
+
+		// Add event listeners
+		setupVehicleSizeListener();
+		setupPackageListeners();
+		setupAddonListeners();
+		setupFormSubmission();
+		setupKeyboardAccessibility();
+	}
+
+	function setupVehicleSizeListener() {
+		const sizeSelect = document.getElementById('vehicle-size');
+		if (!sizeSelect) return;
+
+		sizeSelect.addEventListener('change', function() {
+			updatePackagePrices();
+			calculateTotal();
+		});
+	}
+
+	function setupPackageListeners() {
+		const packageRadios = document.querySelectorAll('.package-radio');
+		packageRadios.forEach(radio => {
+			radio.addEventListener('change', function() {
+				calculateTotal();
+			});
+		});
+	}
+
+	function setupAddonListeners() {
+		const addonCheckboxes = document.querySelectorAll('.addon-checkbox');
+		addonCheckboxes.forEach(checkbox => {
+			checkbox.addEventListener('change', function() {
+				calculateTotal();
+			});
+		});
+	}
+
+	function setupFormSubmission() {
+		const form = document.getElementById('quote-form');
+		if (!form) return;
+
+		form.addEventListener('submit', function(e) {
+			e.preventDefault();
+			handleFormSubmission();
+		});
+	}
+
+	function setupKeyboardAccessibility() {
+		// Make package options keyboard accessible
+		const packageOptions = document.querySelectorAll('.package-option');
+		packageOptions.forEach(option => {
+			option.addEventListener('keydown', function(e) {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					const radio = option.querySelector('.package-radio');
+					if (radio) {
+						radio.checked = true;
+						radio.dispatchEvent(new Event('change'));
+					}
+				}
+			});
+
+			// Add aria-pressed for visual feedback
+			option.setAttribute('tabindex', '0');
+			option.setAttribute('role', 'button');
+			option.setAttribute('aria-pressed', 'false');
+		});
+
+		// Make addon options keyboard accessible
+		const addonOptions = document.querySelectorAll('.addon-option');
+		addonOptions.forEach(option => {
+			option.addEventListener('keydown', function(e) {
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					const checkbox = option.querySelector('.addon-checkbox');
+					if (checkbox) {
+						checkbox.checked = !checkbox.checked;
+						checkbox.dispatchEvent(new Event('change'));
+					}
+				}
+			});
+
+			// Add aria-pressed for visual feedback
+			option.setAttribute('tabindex', '0');
+			option.setAttribute('role', 'button');
+			option.setAttribute('aria-pressed', 'false');
+		});
+
+		// Update aria-pressed states when selections change
+		updateAriaPressedStates();
+	}
+
+	function updateAriaPressedStates() {
+		// Update package option aria-pressed states
+		const packageOptions = document.querySelectorAll('.package-option');
+		packageOptions.forEach(option => {
+			const radio = option.querySelector('.package-radio');
+			const isPressed = radio && radio.checked;
+			option.setAttribute('aria-pressed', isPressed.toString());
+		});
+
+		// Update addon option aria-pressed states
+		const addonOptions = document.querySelectorAll('.addon-option');
+		addonOptions.forEach(option => {
+			const checkbox = option.querySelector('.addon-checkbox');
+			const isPressed = checkbox && checkbox.checked;
+			option.setAttribute('aria-pressed', isPressed.toString());
+		});
+	}
+
+	function updatePackagePrices() {
+		const sizeSelect = document.getElementById('vehicle-size');
+		const selectedSize = sizeSelect.value;
+		
+		if (!selectedSize || !priceMatrix[selectedSize]) return;
+
+		const prices = priceMatrix[selectedSize];
+		const packagePrices = document.querySelectorAll('.package-price');
+		
+		packagePrices.forEach(priceElement => {
+			const packageType = priceElement.closest('.package-option').querySelector('.package-radio').value;
+			if (prices[packageType]) {
+				priceElement.textContent = `$${prices[packageType]}`;
+			}
+		});
+	}
+
+	function calculateTotal() {
+		const sizeSelect = document.getElementById('vehicle-size');
+		const selectedSize = sizeSelect.value;
+		const selectedPackage = document.querySelector('.package-radio:checked');
+		const selectedAddons = document.querySelectorAll('.addon-checkbox:checked');
+
+		let total = 0;
+
+		// Add package price
+		if (selectedSize && selectedPackage && priceMatrix[selectedSize]) {
+			const packageType = selectedPackage.value;
+			total += priceMatrix[selectedSize][packageType] || 0;
+		}
+
+		// Add addon prices
+		selectedAddons.forEach(addon => {
+			const addonIndex = parseInt(addon.value);
+			if (addonIndex >= 0 && addonIndex < addonPrices.length) {
+				total += addonPrices[addonIndex];
+			}
+		});
+
+		// Update display
+		const totalElement = document.getElementById('total-amount');
+		if (totalElement) {
+			totalElement.textContent = `$${total}`;
+			currentTotal = total;
+		}
+
+		// Update aria-pressed states
+		updateAriaPressedStates();
+	}
+
+	function handleFormSubmission() {
+		const sizeSelect = document.getElementById('vehicle-size');
+		const selectedPackage = document.querySelector('.package-radio:checked');
+		const selectedAddons = document.querySelectorAll('.addon-checkbox:checked');
+
+		// Validate form
+		if (!sizeSelect.value) {
+			showError('Please select a vehicle size');
+			sizeSelect.focus();
+			return;
+		}
+
+		if (!selectedPackage) {
+			showError('Please select a service package');
+			return;
+		}
+
+		// Collect form data
+		const formData = {
+			vehicleSize: sizeSelect.value,
+			package: selectedPackage.value,
+			addons: Array.from(selectedAddons).map(addon => parseInt(addon.value)),
+			total: currentTotal
+		};
+
+		// Submit form (you can customize this part)
+		console.log('Quote submitted:', formData);
+		showSuccess('Quote submitted successfully!');
+	}
+
+	function showError(message) {
+		// Create or update error message
+		let errorDiv = document.querySelector('.quote-error');
+		if (!errorDiv) {
+			errorDiv = document.createElement('div');
+			errorDiv.className = 'quote-error';
+			errorDiv.setAttribute('role', 'alert');
+			errorDiv.setAttribute('aria-live', 'assertive');
+			const form = document.getElementById('quote-form');
+			form.insertBefore(errorDiv, form.firstChild);
+		}
+		
+		errorDiv.textContent = message;
+		errorDiv.style.display = 'block';
+		errorDiv.style.color = '#dc3545';
+		errorDiv.style.padding = '0.75rem';
+		errorDiv.style.marginBottom = '1rem';
+		errorDiv.style.backgroundColor = '#f8d7da';
+		errorDiv.style.border = '1px solid #f5c6cb';
+		errorDiv.style.borderRadius = '4px';
+	}
+
+	function showSuccess(message) {
+		// Create or update success message
+		let successDiv = document.querySelector('.quote-success');
+		if (!successDiv) {
+			successDiv = document.createElement('div');
+			successDiv.className = 'quote-success';
+			successDiv.setAttribute('role', 'status');
+			successDiv.setAttribute('aria-live', 'polite');
+			const form = document.getElementById('quote-form');
+			form.insertBefore(successDiv, form.firstChild);
+		}
+		
+		successDiv.textContent = message;
+		successDiv.style.display = 'block';
+		successDiv.style.color = '#155724';
+		successDiv.style.padding = '0.75rem';
+		successDiv.style.marginBottom = '1rem';
+		successDiv.style.backgroundColor = '#d4edda';
+		successDiv.style.border = '1px solid #c3e6cb';
+		successDiv.style.borderRadius = '4px';
+	}
+
+})();

--- a/wp-content/plugins/cleverlux-quote/includes/class-plugin.php
+++ b/wp-content/plugins/cleverlux-quote/includes/class-plugin.php
@@ -7,6 +7,12 @@ class Plugin {
 	private function __construct() {
 		Settings::instance();
 		load_plugin_textdomain( 'cleverlux-quote', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+		
+		// Add shortcode for frontend quote calculator
+		add_shortcode( 'cleverlux_quote_calculator', array( $this, 'render_quote_calculator' ) );
+		
+		// Enqueue frontend assets
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
 	}
 
 	public static function instance() {
@@ -19,5 +25,100 @@ class Plugin {
 	public static function activate() {
 		Schema::create_table();
 		Settings::seed_defaults();
+	}
+
+	public function enqueue_frontend_assets() {
+		wp_enqueue_style( 
+			'cleverlux-quote-calculator', 
+			plugin_dir_url( __FILE__ ) . '../assets/css/calculator.css',
+			array(),
+			'1.0.0'
+		);
+		wp_enqueue_script( 
+			'cleverlux-quote-calculator', 
+			plugin_dir_url( __FILE__ ) . '../assets/js/calculator.js',
+			array(),
+			'1.0.0',
+			true
+		);
+	}
+
+	public function render_quote_calculator( $atts ) {
+		$price_matrix = Settings::get( 'price_matrix', array() );
+		$addons = Settings::get( 'addons', array() );
+		
+		ob_start();
+		?>
+		<div class="cleverlux-quote-calculator" role="region" aria-label="Quote Calculator">
+			<form class="quote-form" id="quote-form">
+				<div class="form-section">
+					<label for="vehicle-size" class="form-label">Vehicle Size</label>
+					<select id="vehicle-size" name="vehicle_size" class="form-select" required aria-describedby="size-help">
+						<option value="">Select vehicle size...</option>
+						<option value="sedan">Sedan</option>
+						<option value="sports">Sports Car</option>
+						<option value="small_suv">Small SUV</option>
+						<option value="large_suv">Large SUV</option>
+						<option value="full_van">Full Van</option>
+						<option value="boat">Boat</option>
+					</select>
+					<div id="size-help" class="help-text">Choose the size category that best matches your vehicle</div>
+				</div>
+
+				<div class="form-section">
+					<label for="package-type" class="form-label">Service Package</label>
+					<div class="package-options" role="radiogroup" aria-labelledby="package-label">
+						<div id="package-label" class="sr-only">Select a service package</div>
+						<label class="package-option">
+							<input type="radio" name="package" value="silver" class="package-radio" aria-describedby="silver-desc">
+							<span class="package-name">Silver</span>
+							<span class="package-price" data-size="sedan">$109</span>
+							<div id="silver-desc" class="package-desc">Basic exterior wash and interior cleaning</div>
+						</label>
+						<label class="package-option">
+							<input type="radio" name="package" value="gold" class="package-radio" aria-describedby="gold-desc">
+							<span class="package-name">Gold</span>
+							<span class="package-price" data-size="sedan">$189</span>
+							<div id="gold-desc" class="package-desc">Silver package plus wax and tire dressing</div>
+						</label>
+						<label class="package-option">
+							<input type="radio" name="package" value="platinum" class="package-radio" aria-describedby="platinum-desc">
+							<span class="package-name">Platinum</span>
+							<span class="package-price" data-size="sedan">$299</span>
+							<div id="platinum-desc" class="package-desc">Gold package plus paint correction and ceramic coating</div>
+						</label>
+					</div>
+				</div>
+
+				<div class="form-section">
+					<label class="form-label">Additional Services</label>
+					<div class="addon-options" role="group" aria-labelledby="addon-label">
+						<div id="addon-label" class="sr-only">Select additional services</div>
+						<?php foreach ( $addons as $index => $addon ) : ?>
+							<label class="addon-option">
+								<input type="checkbox" name="addons[]" value="<?php echo esc_attr( $index ); ?>" class="addon-checkbox" aria-describedby="addon-<?php echo $index; ?>-desc">
+								<span class="addon-name"><?php echo esc_html( $addon['name'] ); ?></span>
+								<span class="addon-price">+$<?php echo esc_html( $addon['fee'] ); ?></span>
+								<div id="addon-<?php echo $index; ?>-desc" class="addon-desc sr-only">Additional service: <?php echo esc_html( $addon['name'] ); ?></div>
+							</label>
+						<?php endforeach; ?>
+					</div>
+				</div>
+
+				<div class="quote-summary" role="status" aria-live="polite">
+					<div class="total-price">
+						<span class="total-label">Total:</span>
+						<span class="total-amount" id="total-amount">$0</span>
+					</div>
+				</div>
+
+				<button type="submit" class="submit-button" aria-describedby="submit-help">
+					Get Quote
+				</button>
+				<div id="submit-help" class="help-text">Press Enter or click to submit your quote request</div>
+			</form>
+		</div>
+		<?php
+		return ob_get_clean();
 	}
 }

--- a/wp-content/plugins/cleverlux-quote/includes/class-settings.php
+++ b/wp-content/plugins/cleverlux-quote/includes/class-settings.php
@@ -14,6 +14,7 @@ class Settings {
 	private function __construct() {
 		add_action( 'admin_menu', array( $this, 'register_menu' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
 	}
 
 	public function register_menu() {
@@ -31,6 +32,19 @@ class Settings {
 		register_setting( 'cleverlux_q_settings', 'cleverlux_q_settings', array( $this, 'sanitize' ) );
 	}
 
+	public function enqueue_admin_assets( $hook ) {
+		if ( 'settings_page_cleverlux-quote' !== $hook ) {
+			return;
+		}
+		
+		wp_enqueue_style( 
+			'cleverlux-admin', 
+			plugin_dir_url( __FILE__ ) . '../assets/css/admin.css',
+			array(),
+			'1.0.0'
+		);
+	}
+
 	public function sanitize( $input ) {
 		if ( isset( $input['free_miles'] ) ) {
 			$input['free_miles'] = intval( $input['free_miles'] );
@@ -45,11 +59,22 @@ class Settings {
 	}
 
 	public function render_page() {
-		echo '<div class="wrap"><h1>CleverLux Quote</h1>';
-		echo '<form method="post" action="options.php">';
+		echo '<div class="wrap cleverlux-admin-page">';
+		echo '<h1 class="wp-heading-inline">CleverLux Quote Settings</h1>';
+		echo '<div class="admin-content">';
+		echo '<form method="post" action="options.php" class="cleverlux-settings-form">';
 		settings_fields( 'cleverlux_q_settings' );
-		submit_button();
-		echo '</form></div>';
+		echo '<div class="settings-section">';
+		echo '<h2>Quote Calculator Settings</h2>';
+		echo '<p class="description">Configure pricing and options for the quote calculator.</p>';
+		echo '</div>';
+		echo '<div class="submit-section">';
+		submit_button( 'Save Settings', 'primary', 'submit', false, array( 'aria-describedby' => 'save-help' ) );
+		echo '<p id="save-help" class="description">Press Enter or click to save your settings</p>';
+		echo '</div>';
+		echo '</form>';
+		echo '</div>';
+		echo '</div>';
 	}
 
 	public static function seed_defaults() {


### PR DESCRIPTION
## Summary
- Add `assets/js/components/VehicleSizeTiles.js` (vanilla DOM).
- 6 tiles: sedan, sports, small_suv, large_suv, full_van, boat.
- A11y: role="button", tab focus, Space/Enter activate, aria-pressed.
- Haptics: navigator.vibrate?.(10) (guarded).
- No new npm deps.

