### PR TITLE
Fix wp qa checks in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,35 @@ jobs:
           shopt -s globstar nullglob
           # Limit search scope to repo, excluding common vendor dirs
           EXCLUDES=( -path './.git/*' -o -path './node_modules/*' -o -path './vendor/*' -o -path './dist/*' -o -path './build/*' )
-          php_files=$(find . -type f -name '*.php' ! \( ${EXCLUDES[@]} \) -print)
+          # Build a null-delimited array of PHP files to safely handle spaces
+          mapfile -d '' -t php_files < <(find . -type f -name '*.php' ! \( "${EXCLUDES[@]}" \) -print0)
+
+          # If nothing to check (all PHP files excluded), exit early
+          if [ ${#php_files[@]} -eq 0 ]; then
+            exit 0
+          fi
 
           # 1) Enqueue only with shortcode context present
-          enq_files=$(grep -IlE 'wp_enqueue_script|wp_enqueue_style' $php_files || true)
-          for f in $enq_files; do
+          while IFS= read -r -d '' f; do
             grep -Eq 'has_shortcode\(|add_shortcode\(|shortcode_atts\(' "$f" || { echo "::error file=$f::Asset enqueue must be gated by a shortcode (has_shortcode/add_shortcode)."; exit 1; }
-          done
+          done < <(grep -IlZ -E 'wp_enqueue_script|wp_enqueue_style' -- "${php_files[@]}" || true)
 
           # 2) dbDelta is called safely with upgrade.php required
-          db_files=$(grep -Il 'dbDelta\(' $php_files || true)
-          for f in $db_files; do
+          while IFS= read -r -d '' f; do
             grep -Eq 'require_once.*wp-admin/includes/upgrade\.php' "$f" || { echo "::error file=$f::dbDelta requires including wp-admin/includes/upgrade.php"; exit 1; }
-          done
+          done < <(grep -IlZ 'dbDelta\(' -- "${php_files[@]}" || true)
 
           # 3) No global leaks (allow only $wpdb)
-          bad_globals=$(grep -In '^[[:space:]]*global[[:space:]]+\$' $php_files | grep -vE '\$wpdb([[:space:],;)]|$)' || true)
-          [ -z "$bad_globals" ] || { echo "$bad_globals" | while IFS=: read -r file line _; do echo "::error file=$file,line=$line::Avoid global variables (except \$wpdb)."; done; exit 1; }
+          violations=0
+          while IFS=: read -r file line content; do
+            # Allow only lines that declare $wpdb (optionally repeated) and nothing else
+            if [[ "$content" =~ ^[[:space:]]*global[[:space:]]+(\$wpdb[[:space:]]*)(,[[:space:]]*\$wpdb[[:space:]]*)*;([[:space:]]*(//|#).*)?$ ]]; then
+              continue
+            fi
+            echo "::error file=$file,line=$line::Avoid global variables (except \$wpdb)."
+            violations=1
+          done < <(grep -InE '^[[:space:]]*global[[:space:]]+\$' -- "${php_files[@]}" || true)
+
+          if [ "$violations" -ne 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
Fixes WP QA checks in CI by handling file paths with spaces, ensuring CI fails on global variable violations, and tightening the global variable regex.

The original implementation had several issues: unquoted variables led to word splitting, breaking checks for paths with spaces. The global variable check's `exit 1` was in a subshell, preventing CI from failing. Additionally, its regex allowed other global variables if `$wpdb` was present on the same line. These changes address all these points for more robust and accurate CI checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-be4322b6-24e6-4965-a727-d16b4417480f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be4322b6-24e6-4965-a727-d16b4417480f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

