### PR TITLE
1: WordPress plugin scaffold + shortcode

### DIFF
--- a/cleverlux-quote/assets/css/calculator.css
+++ b/cleverlux-quote/assets/css/calculator.css
@@ -1,0 +1,1 @@
+/* Placeholder styles for CleverLux Quote Calculator */

--- a/cleverlux-quote/assets/js/calculator.js
+++ b/cleverlux-quote/assets/js/calculator.js
@@ -1,0 +1,1 @@
+/* Placeholder script for CleverLux Quote Calculator */

--- a/cleverlux-quote/cleverlux-quote.php
+++ b/cleverlux-quote/cleverlux-quote.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name:       CleverLux Quote
+ * Description:       Provides the [cleverlux_quote_calculator] shortcode.
+ * Version:           0.1.0
+ * Author:            CleverLux
+ */
+
+namespace CleverLux\Quote;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'CLEVERLUX_QUOTE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'CLEVERLUX_QUOTE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+
+require_once CLEVERLUX_QUOTE_PLUGIN_PATH . 'includes/class-plugin.php';
+require_once CLEVERLUX_QUOTE_PLUGIN_PATH . 'includes/class-assets.php';
+require_once CLEVERLUX_QUOTE_PLUGIN_PATH . 'sql/schema.php';
+
+function activate() : void {
+    Schema\create_tables();
+}
+register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
+
+function run() : void {
+    $plugin = new Plugin();
+    $plugin->init();
+}
+run();

--- a/cleverlux-quote/includes/class-assets.php
+++ b/cleverlux-quote/includes/class-assets.php
@@ -1,0 +1,30 @@
+<?php
+namespace CleverLux\Quote;
+
+class Assets {
+    public function init() : void {
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
+    }
+
+    public function enqueue() : void {
+        $post = get_post();
+        if ( ! $post || ! has_shortcode( $post->post_content, 'cleverlux_quote_calculator' ) ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'cleverlux-quote-calculator',
+            CLEVERLUX_QUOTE_PLUGIN_URL . 'assets/css/calculator.css',
+            [],
+            '0.1.0'
+        );
+
+        wp_enqueue_script(
+            'cleverlux-quote-calculator',
+            CLEVERLUX_QUOTE_PLUGIN_URL . 'assets/js/calculator.js',
+            [],
+            '0.1.0',
+            true
+        );
+    }
+}

--- a/cleverlux-quote/includes/class-plugin.php
+++ b/cleverlux-quote/includes/class-plugin.php
@@ -1,0 +1,21 @@
+<?php
+namespace CleverLux\Quote;
+
+class Plugin {
+    public function init() : void {
+        add_shortcode( 'cleverlux_quote_calculator', [ $this, 'render' ] );
+        $assets = new Assets();
+        $assets->init();
+    }
+
+    /**
+     * Render placeholder form for quote calculator.
+     */
+    public function render( array $atts = [], ?string $content = null ) : string {
+        $output  = '<form class="cleverlux-quote-form">';
+        $output .= '<input type="text" placeholder="' . esc_attr__( 'Your car model', 'cleverlux-quote' ) . '" />';
+        $output .= wp_nonce_field( 'cleverlux_quote_submit', 'cleverlux_quote_nonce', true, false );
+        $output .= '</form>';
+        return $output;
+    }
+}

--- a/cleverlux-quote/readme.txt
+++ b/cleverlux-quote/readme.txt
@@ -1,0 +1,2 @@
+=== CleverLux Quote ===
+Provides the [cleverlux_quote_calculator] shortcode.

--- a/cleverlux-quote/sql/schema.php
+++ b/cleverlux-quote/sql/schema.php
@@ -1,0 +1,18 @@
+<?php
+namespace CleverLux\Quote\Schema;
+
+function create_tables() : void {
+    global $wpdb;
+
+    $table_name      = $wpdb->prefix . 'cleverlux_quotes';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        created_at datetime NOT NULL,
+        PRIMARY KEY  (id)
+    ) $charset_collate;";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+}


### PR DESCRIPTION
## Summary
- scaffold initial CleverLux Quote plugin with shortcode
- enqueue plugin assets only when shortcode is present
- add activation routine to create database table via dbDelta

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bash -lc 'set -e; for f in $(rg -l "wp_enqueue_(script|style)" -g "*.php" cleverlux-quote); do rg -q "has_shortcode|add_shortcode|shortcode_atts" "$f" || { echo "missing gating in $f"; exit 1; }; done; echo "enqueue gating ok"'`
- `bash -lc 'set -e; for f in $(rg -l "dbDelta\(" -g "*.php" cleverlux-quote); do rg -q "require_once.*wp-admin/includes/upgrade\.php" "$f" || { echo "missing upgrade.php in $f"; exit 1; }; done; echo "dbDelta check ok"'`
- `bash -lc 'violations=$(rg -n "^[[:space:]]*global[[:space:]]+\$" -g "*.php" cleverlux-quote | rg -v "\$wpdb" || true); if [ -n "$violations" ]; then echo "$violations"; exit 1; fi; echo "globals check ok"'`


------
https://chatgpt.com/codex/tasks/task_e_689d85e9e9888323b86819da9f43b321