### PR TITLE
Fix ci bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,23 @@ jobs:
       - name: Build
         if: ${{ hashFiles('package.json') != '' }}
         run: npm run build --if-present
+      - name: WP QA checks
+        if: ${{ hashFiles('**/*.php') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          php_files=$(git ls-files '*.php' || true)
+          if [ -z "$php_files" ]; then
+            echo "No PHP files found; skipping."
+            exit 0
+          fi
+          echo "Found PHP files. Running header checks."
+          if ! grep -RIl --include='*.php' -F 'Plugin Name:' . >/dev/null; then
+            echo "Missing 'Plugin Name:' header in any PHP file."
+            exit 1
+          fi
+          if ! grep -RIl --include='*.php' -F 'Version:' . >/dev/null; then
+            echo "Missing 'Version:' header in any PHP file."
+            exit 1
+          fi
+          echo "WP QA checks passed." 


### PR DESCRIPTION
Add a 'WP QA checks' step to the CI workflow to prevent `grep: Unmatched (` errors.

This step conditionally runs if PHP files exist and uses specific `grep` flags (`-F`) to avoid regex parsing issues that caused the previous CI failure related to unmatched parentheses in the `grep` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-01cd8ce7-91e5-46a4-8cfd-0f66f6db9dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01cd8ce7-91e5-46a4-8cfd-0f66f6db9dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

