### PR TITLE
Fix ci workflow error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,20 @@ jobs:
         if: ${{ hashFiles('package.json') != '' }}
         run: npm run build --if-present
       - name: WP QA checks
-        if: ${{ hashFiles('**/*.php') != '' }}
         shell: bash
         run: |
           set -euo pipefail
-          php_files=$(git ls-files '*.php' || true)
+          php_files=$(git ls-files '*.php' 2>/dev/null || true)
           if [ -z "$php_files" ]; then
             echo "No PHP files found; skipping."
             exit 0
           fi
           echo "Found PHP files. Running header checks."
-          if ! grep -RIl --include='*.php' -F 'Plugin Name:' . >/dev/null; then
+          if ! grep -RIl --include='*.php' -F 'Plugin Name:' . >/dev/null 2>&1; then
             echo "Missing 'Plugin Name:' header in any PHP file."
             exit 1
           fi
-          if ! grep -RIl --include='*.php' -F 'Version:' . >/dev/null; then
+          if ! grep -RIl --include='*.php' -F 'Version:' . >/dev/null 2>&1; then
             echo "Missing 'Version:' header in any PHP file."
             exit 1
           fi


### PR DESCRIPTION
Fixes CI workflow error in WP QA checks by improving PHP file detection and error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bfd120d-96c2-4d89-9c2a-ea28de7a9411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bfd120d-96c2-4d89-9c2a-ea28de7a9411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

