### PR TITLE
3: lookupVehicleSize (pure function) + tests

### DIFF
--- a/assets/js/hooks/useVehicleLookup.js
+++ b/assets/js/hooks/useVehicleLookup.js
@@ -1,0 +1,36 @@
+const models = require('../data/vehicle-models.json');
+
+let index;
+
+const ALIASES = {
+  'c class': 'mercedes benz c class',
+  'mercedes c class': 'mercedes benz c class',
+};
+
+function normalize(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^\w\s]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getIndex() {
+  if (!index) {
+    index = new Map();
+    for (const { make, model, size } of models) {
+      const key = normalize(`${make} ${model}`);
+      index.set(key, size);
+    }
+  }
+  return index;
+}
+
+function lookupVehicleSize(name) {
+  if (typeof name !== 'string') return null;
+  const normalized = normalize(name);
+  const key = ALIASES[normalized] || normalized;
+  return getIndex().get(key) || null;
+}
+
+module.exports = lookupVehicleSize;

--- a/test/useVehicleLookup.test.js
+++ b/test/useVehicleLookup.test.js
@@ -1,0 +1,23 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const lookupVehicleSize = require('../assets/js/hooks/useVehicleLookup');
+
+test('exact match', () => {
+  assert.strictEqual(lookupVehicleSize('Honda Accord'), 'sedan');
+});
+
+test('case and extra spaces ignored', () => {
+  assert.strictEqual(lookupVehicleSize('  hOnDa   aCcOrD  '), 'sedan');
+});
+
+test('punctuation ignored', () => {
+  assert.strictEqual(lookupVehicleSize('Honda Accord!!!'), 'sedan');
+});
+
+test('alias lookup', () => {
+  assert.strictEqual(lookupVehicleSize('c class'), 'sedan');
+});
+
+test('unknown returns null', () => {
+  assert.strictEqual(lookupVehicleSize('Unknown Model'), null);
+});


### PR DESCRIPTION
## Summary
- add pure lookupVehicleSize function and lazy index
- test lookupVehicleSize for normalization, aliases, and unknown models

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689e0a04e3d08323a2cb5c08a75ceb5f